### PR TITLE
正規表現周りのリファクタリングをする

### DIFF
--- a/nippoa.cabal
+++ b/nippoa.cabal
@@ -78,8 +78,6 @@ test-suite nippoa-test
                      , bytestring ==0.10.6.0
                      , filepath ==1.4.0.0
                      , time ==1.5.0.1
-                     , regex-compat ==0.95.1
-                     , utf8-string ==1.0.1.1
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/nippoa.cabal
+++ b/nippoa.cabal
@@ -32,6 +32,7 @@ library
                      , Slack.Organizer
                      , Utility.Base
                      , Utility.Time
+                     , Utility.Regex
   build-depends:       base >= 4.7 && < 5
                      , http-conduit ==2.1.11
                      , aeson ==0.11.2.0
@@ -72,6 +73,7 @@ test-suite nippoa-test
                      , Slack.OrganizerSpec
                      , Utility.BaseSpec
                      , Utility.TimeSpec
+                     , Utility.RegexSpec
   build-depends:       base
                      , hspec ==2.2.3
                      , nippoa

--- a/src/Slack/Message.hs
+++ b/src/Slack/Message.hs
@@ -32,20 +32,15 @@ import Data.Time.Format
 import Data.Time.Clock
   ( UTCTime
   )
-import Text.Regex
-  ( mkRegex
-  , subRegex
-  , splitRegex
-  )
-import Codec.Binary.UTF8.String
-  ( encodeString
-  , decodeString
-  )
 import Slack.Attachment
   ( Attachment(..)
   )
 import Utility.Time
   ( jst
+  )
+import Utility.Regex
+  ( split
+  , replace
   )
 
 data Message
@@ -105,16 +100,16 @@ messageTemplate x =
       | x == "" = x
       | otherwise = concat . map addSite . splitLine $ x
       where
-        splitLine = splitRegex (mkRegex "\n")
+        splitLine = split "\n"
         addSite x = "> " ++ x ++ "\n" :: String
 
 toMarkdown :: String -> String
 toMarkdown =
-    decodeString . toImageIfExists . toMarkdownOnlyLink . toMarkdownWithLabel . encodeString
+    toImageIfExists . toMarkdownOnlyLink . toMarkdownWithLabel
   where
-    toMarkdownWithLabel x = subRegex regexWithLabel x "[\\2](\\1)"
-    toMarkdownOnlyLink x = subRegex regexOnlyLink x "[\\1](\\1)"
-    toImageIfExists x = subRegex regexWithImage x "!\\1"
-    regexWithLabel = mkRegex "<([^<>\\|]+)\\|([^<>]+)>"
-    regexOnlyLink = mkRegex "<([^<>\\|]+)>"
-    regexWithImage = mkRegex "(\\[[^\\]*\\]\\([^\\)]+\\.(gif|png|jpe?g)\\))"
+    toMarkdownWithLabel = replaceWithLabel "[\\2](\\1)"
+    toMarkdownOnlyLink = replaceOnlyLink "[\\1](\\1)"
+    toImageIfExists = replaceWithImage "!\\1"
+    replaceWithLabel = replace "<([^<>\\|]+)\\|([^<>]+)>"
+    replaceOnlyLink = replace "<([^<>\\|]+)>"
+    replaceWithImage = replace "(\\[[^\\]*\\]\\([^\\)]+\\.(gif|png|jpe?g)\\))"

--- a/src/Slack/Organizer.hs
+++ b/src/Slack/Organizer.hs
@@ -8,16 +8,8 @@ module Slack.Organizer
 import Text.Printf
   ( printf
   )
-import Text.Regex
-  ( mkRegex
-  , matchRegex
-  )
 import Data.Maybe
   ( fromMaybe
-  )
-import Codec.Binary.UTF8.String
-  ( encodeString
-  , decodeString
   )
 import Nippoa.Record
   ( Record(..)
@@ -62,6 +54,9 @@ import Utility.Base
   ( liftJustList
   , filterJust
   , isMaybe
+  )
+import Utility.Regex
+  ( match
   )
 
 data Organizer
@@ -116,9 +111,7 @@ recordsByMessage this x =
               }
             otherwise -> Nothing
       where
-        matchGitHubComment :: String -> Maybe [String]
-        matchGitHubComment x = map decodeString <$> (matchRegex regexGitHubComment . encodeString $ x)
-        regexGitHubComment = mkRegex "New comment by .* <(.*)\\|(.*)>"
+        matchGitHubComment = match "New comment by .* <(.*)\\|(.*)>"
     returnUserById = returnUser . userById (usersList this)
     returnUser = fromMaybe (error "User Not Found")
 

--- a/src/Utility/Regex.hs
+++ b/src/Utility/Regex.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE CPP #-}
+module Utility.Regex
+  ( match
+  , split
+  , replace
+  ) where
+
+import Text.Regex
+  ( mkRegex
+  , matchRegex
+  , splitRegex
+  , subRegex
+  )
+import Codec.Binary.UTF8.String
+  ( encodeString
+  , decodeString
+  )
+
+match :: String -> String -> Maybe [String]
+match regtext source =
+    map decodeString <$> (matchRegex regex . encodeString) source
+  where
+    regex = mkRegex regtext
+
+split :: String -> String -> [String]
+split regtext =
+    map decodeString . splitRegex regex . encodeString
+  where
+    regex = mkRegex regtext
+
+replace :: String -> String -> String -> String
+replace regtext reptext source =
+    decodeString . subRegex regex (encodeString source) $ reptext
+  where
+    regex = mkRegex regtext

--- a/test/SandboxSpec.hs
+++ b/test/SandboxSpec.hs
@@ -3,9 +3,6 @@ module SandboxSpec where
 
 import Test.Hspec
 
-import Text.Regex
-import Codec.Binary.UTF8.String
-
 example0 :: Maybe Bool
 example0 = Just True
 
@@ -20,11 +17,6 @@ example2 x = show <$> (+3) <$> (*3) <$> Just x
 
 example3 :: Maybe [Int]
 example3 = map (+3) <$> Just [1, 2]
-
-example4 :: Maybe [String]
-example4 = map decodeString <$> (matchRegex regex . encodeString) "<test>"
-  where
-    regex = mkRegex "<(.*)>"
 
 spec :: Spec
 spec = do
@@ -44,7 +36,3 @@ spec = do
   describe "example3" $ do
     it "should return maybe true" $ do
       example3 `shouldBe` Just [4, 5]
-
-  describe "example4" $ do
-    it "should return maybe true" $ do
-      example4 `shouldBe` Just ["test"]

--- a/test/Utility/RegexSpec.hs
+++ b/test/Utility/RegexSpec.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+module Utility.RegexSpec where
+
+import Utility.Regex
+import Test.Hspec
+
+spec :: Spec
+spec = do
+
+  describe "match" $ do
+    it "should match using regex" $ do
+      match "<(.*)>" "<hello>" `shouldBe` Just ["hello"]
+      match "<.*>" "<hello>" `shouldBe` Just []
+      match "<.*>" "[hello]" `shouldBe` Nothing
+
+  describe "split" $ do
+    it "should split using regex" $ do
+      split "," "hello,world" `shouldBe` ["hello", "world"]
+      split "," "hello world" `shouldBe` ["hello world"]
+
+  describe "replace" $ do
+    it "should replace using regex" $ do
+      replace "<(.*)>" "\\1" "<hello>" `shouldBe` "hello"


### PR DESCRIPTION
そろそろPR駆動してみる。

HaskellでUTF8の正規表現を扱おうとすると、
いろいろ問題が起こることが多いので、そうならないための共通関数を準備しておく。

参考: Haskellでの多バイト文字の処理
http://d.hatena.ne.jp/hideshi_o/20120906/1346918677