### PR TITLE
Slack.Messageモジュールから使っていない関数を削除する

### DIFF
--- a/src/Slack/Message.hs
+++ b/src/Slack/Message.hs
@@ -18,8 +18,7 @@ import Slack.Attachment
   ( Attachment(..)
   )
 import Utility.Regex
-  ( split
-  , replace
+  ( replace
   )
 
 data Message

--- a/test/Slack/MessageSpec.hs
+++ b/test/Slack/MessageSpec.hs
@@ -5,8 +5,6 @@ import Slack.Message
 import Test.Hspec
 import Slack.AttachmentSpec
 
-import Data.Time.Format
-
 message0 :: Message
 message0
   = Message
@@ -56,16 +54,6 @@ spec = do
     it "should return initial value" $ do
       messageBotId message0 `shouldBe` Just "botid0"
       messageBotId message1 `shouldBe` Just "botid1"
-
-  describe "messageDateTime" $ do
-    it "should return initial value" $ do
-      let format = formatTime defaultTimeLocale "%F %T"
-      format (messageDateTime message0) `shouldBe` "2016-07-29 14:01:18"
-      format (messageDateTime message1) `shouldBe` "2016-07-29 14:01:18"
-
-  describe "messageTemplate" $ do
-    it "should return template text of message" $ do
-      pending
 
   describe "toMarkdown" $ do
     it "should return text to markdown" $ do


### PR DESCRIPTION
既にNippoa.Recordに似たようなのが移植されているので。
