### PR TITLE
いまいちな関数名を変更する

### DIFF
--- a/src/Index.hs
+++ b/src/Index.hs
@@ -24,11 +24,11 @@ execute = do
     channelName <- getEnv "SLACK_CHANNEL_NAME"
     organizer <- getOrganizer token
     (date1, date2) <- getDate
-    let channel = returnChannel $ channelByName organizer channelName
+    let channel = fromMaybeChannel $ channelByName organizer channelName
     json <- getJsonFromGroupsHistory token channel date1 date2
     putStrLn . messagesTextFrom organizer $ json
   where
-    returnChannel = fromMaybe (error "Channel Not Found")
+    fromMaybeChannel = fromMaybe (error "Channel Not Found")
     messagesTextFrom organizer =
       concat . reverse . map (newline . recordRender) .
       concatMap (recordsByMessage organizer) . historyMessages . parseHistory

--- a/src/Slack/Organizer.hs
+++ b/src/Slack/Organizer.hs
@@ -137,7 +137,7 @@ recordsByMessage this x =
           , plainText = toMarkdown . fromMaybe "" . messageText $ x
           }
           where
-            user = returnUser . userById (organizerUsersList this) $ id
+            user = fromMaybeUser . userById (organizerUsersList this) $ id
         otherwise -> Nothing
     recordByAttachment y =
       case attachmentTitleLink y of
@@ -161,8 +161,7 @@ recordsByMessage this x =
             otherwise -> Nothing
       where
         matchGitHubComment = match "New comment by .* <(.*)\\|(.*)>"
-    returnUserById = returnUser . userById (organizerUsersList this)
-    returnUser = fromMaybe (error "User Not Found")
+    fromMaybeUser = fromMaybe (error "User Not Found")
 
 channelByName :: Organizer -> String -> Maybe Channel
 channelByName this name = case maybeChannel1 of


### PR DESCRIPTION
```haskell
returnChannel :: Maybe a -> a -> a
```

`return`はモナドでくるむ関数なのに、逆なことをしているので。